### PR TITLE
feat: 질문에 대한 답변 조회 API

### DIFF
--- a/src/question/dtos/question.dto.ts
+++ b/src/question/dtos/question.dto.ts
@@ -13,3 +13,29 @@ export class QuestionRandomResponseDto {
     };
   }
 }
+
+export class QuestionRatioRequestDto {
+  questionIds: number[];
+}
+
+export class QuestionRatioResponseDto {
+  id: number;
+  questionA: string;
+  questionB: string;
+  ratioA: number;
+  ratioB: number;
+
+  static of(
+    question: Question,
+    ratioA: number,
+    ratioB: number,
+  ): QuestionRatioResponseDto {
+    return {
+      id: question.id,
+      questionA: question.questionA,
+      questionB: question.questionB,
+      ratioA: ratioA,
+      ratioB: ratioB,
+    };
+  }
+}

--- a/src/question/question.controller.ts
+++ b/src/question/question.controller.ts
@@ -1,6 +1,10 @@
-import { Controller, Get, Query } from '@nestjs/common';
+import { Body, Controller, Get, Query } from '@nestjs/common';
 import { QuestonService } from './question.service';
-import { QuestionRandomResponseDto } from './dtos/question.dto';
+import {
+  QuestionRandomResponseDto,
+  QuestionRatioRequestDto,
+  QuestionRatioResponseDto,
+} from './dtos/question.dto';
 
 @Controller('question')
 export class QuestionController {
@@ -11,5 +15,12 @@ export class QuestionController {
     @Query('fieldId') fieldId: number,
   ): Promise<QuestionRandomResponseDto[]> {
     return this.questionService.getRandomQuestions(fieldId);
+  }
+
+  @Get('/result')
+  getQuestionRatio(
+    @Body() questionRatioRequestDto: QuestionRatioRequestDto,
+  ): Promise<QuestionRatioResponseDto[]> {
+    return this.questionService.getQuestionRatio(questionRatioRequestDto);
   }
 }

--- a/src/question/question.service.ts
+++ b/src/question/question.service.ts
@@ -1,7 +1,11 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { QuestionRepository } from './question.repository';
-import { QuestionRandomResponseDto } from './dtos/question.dto';
+import {
+  QuestionRandomResponseDto,
+  QuestionRatioRequestDto,
+  QuestionRatioResponseDto,
+} from './dtos/question.dto';
 
 @Injectable()
 export class QuestonService {
@@ -47,4 +51,22 @@ export class QuestonService {
     // 앞에서부터 n개의 요소를 선택하여 반환
     return shuffled.slice(0, n);
   };
+
+  async getQuestionRatio(
+    questionRatioRequestDto: QuestionRatioRequestDto,
+  ): Promise<QuestionRatioResponseDto[]> {
+    // questionId에 맞는 질문 리스트 가져오기
+    const questions = await this.questionRepository.getQuestionsById(
+      questionRatioRequestDto.questionIds,
+    );
+
+    const questionRatioResult = questions.map((question) => {
+      // 답변 비율 계산
+      const ratioA: number = question.a / (question.a + question.b);
+      const ratioB: number = question.b / (question.a + question.b);
+      return QuestionRatioResponseDto.of(question, ratioA, ratioB);
+    });
+
+    return questionRatioResult;
+  }
 }


### PR DESCRIPTION
## Issue
close #3 

## 작업 사항
- 질문 id 리스트를 body로 요청하면 해당 질문의 답변 비율을 반환
  - Request: QuestionRatioRequestDto
    - questionIds: number[]
    - ex) "questionIds": [11, 23, 19, 3]
  - Response: QuestionRatioResponseDto[]
```json
[
    {
        "id": 11,
        "questionA": "상사에게 사랑받고 동료에게 미움받기",
        "questionB": "상사에게 미움받고 동료에게 사랑받기",
        "ratioA": 0.16666666666666666,
        "ratioB": 0.8333333333333334
    },
    {
        "id": 23,
        "questionA": "내가 30분 동안 발표하기",
        "questionB": "상사 발표 1시간 듣기",
        "ratioA": 0.8181818181818182,
        "ratioB": 0.18181818181818182
    },
    {
        "id": 19,
        "questionA": "출입구 앞자리",
        "questionB": "팀장님 옆자리",
        "ratioA": 0.5,
        "ratioB": 0.5
    },
    {
        "id": 3,
        "questionA": "스마트폰 키보드+외장 모니터",
        "questionB": "스마트폰 화면+외장 키보드",
        "ratioA": 0.36363636363636365,
        "ratioB": 0.6363636363636364
    }
]
```